### PR TITLE
Unenrol suspended users

### DIFF
--- a/lang/en/enrol_json.php
+++ b/lang/en/enrol_json.php
@@ -48,3 +48,4 @@ $string['failedapicall'] = 'Failed to request api url';
 $string['json:config'] = 'Configure json plugin';
 $string['remotegroupfield'] = 'Remote group field';
 $string['localgroupfield'] = 'Local group field';
+$string['auth_remove_suspend_unenrol'] = 'Suspend internal and unenrol user from course';

--- a/settings.php
+++ b/settings.php
@@ -76,6 +76,7 @@ if ($hassiteconfig) {
         $deleteopt[AUTH_REMOVEUSER_KEEP] = get_string('auth_remove_keep', 'auth');
         $deleteopt[AUTH_REMOVEUSER_SUSPEND] = get_string('auth_remove_suspend', 'auth');
         $deleteopt[AUTH_REMOVEUSER_FULLDELETE] = get_string('auth_remove_delete', 'auth');
+        $deleteopt[AUTH_REMOVEUSER_SUSPEND_UNENROL] = get_string('auth_remove_suspend_unenrol', 'enrol_json');
 
         $settings->add(new admin_setting_configselect('enrol_json/removeuser',
             new lang_string('auth_remove_user_key', 'auth'),

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_json';
 $plugin->release = '0.1.3';
-$plugin->version = 2024091300;
+$plugin->version = 2025091100;
 $plugin->requires = 2020110900;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hi,

This adds a new removeuser setting to unenrol suspended users. 
Currently unless a user is mentioned in the enrolment API with relevant enrolments, they do not get unenroled from the courses they are not suppose to be in. For e.g. if a user does not have any enrolments in the external source then an empty enrollment dataset needs to be sent for the unenrolments to work. 
```
[{
		"studentId": "270642908",
		"firstname": "Selina ",
		"lastname": "Birchfield",
		"email": "270642908@xxxx.ac.nz",
		"enrolments": []
	},
	{
		"studentId": "270043384",
		"firstname": "Timothy",
		"lastname": "Boyd",
		"email": "270043384@xxxx.ac.nz",
		"enrolments": []
	}
        ]
```

With this new setting, if a user disappears from the user API, it will get suspended and get unenrolled from all their courses. 



Regards,
Sumaiya
 