### PR TITLE
Unenrol user missing from Enrolment API but present in User API

### DIFF
--- a/classes/task/sync_enrolments_users.php
+++ b/classes/task/sync_enrolments_users.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Sync enrolments users
+ *
+ * The users that are present in the User API and not in the Enrolment API
+ * are unenroled from all their courses.
+ *
+ * @package   enrol_json
+ * @copyright 2025 Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace enrol_json\task;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class sync_enrolments_users
+ *
+ * @package   enrol_json
+ * @copyright 2021 Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class sync_enrolments_users extends \core\task\scheduled_task {
+
+    /**
+     * Name for this task.
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('syncuserstaskenrolments', 'enrol_json');
+    }
+
+    /**
+     * Run task for synchronising users.
+     */
+    public function execute() {
+
+        $trace = new \text_progress_trace();
+
+        if (!enrol_is_enabled('json')) {
+            $trace->output('Plugin not enabled');
+            return;
+        }
+        if (empty(get_config('enrol_json', 'usersync'))) {
+            $trace->output('User sync disabled');
+            return;
+        }
+
+        $enrol = enrol_get_plugin('json');
+        if (!$enrol->is_configured()) {
+            $trace->output('Plugin not configured');
+            return;
+        }
+        \core_php_time_limit::raise();
+        raise_memory_limit(MEMORY_HUGE);
+
+        $enrol->sync_enrolments_users($trace);
+    }
+}

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -43,5 +43,15 @@ $tasks = [
         'month' => '*',
         'dayofweek' => '*',
         'disabled' => false
+    ],
+    [
+        'classname' => '\enrol_json\task\sync_enrolments_users',
+        'blocking' => 0,
+        'minute' => 'R',
+        'hour' => 'R',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*',
+        'disabled' => true
     ]
 ];

--- a/lang/en/enrol_json.php
+++ b/lang/en/enrol_json.php
@@ -44,8 +44,13 @@ $string['user_data_mapping'] = 'User data mapping';
 $string['privacy:metadata'] = 'The JSON enrolment plugin does not store any personal data.';
 $string['syncenrolmentstask'] = 'Sync enrolments';
 $string['syncuserstask'] = 'Sync users';
+$string['syncuserstaskenrolments'] = 'Sync users enrolments';
 $string['failedapicall'] = 'Failed to request api url';
 $string['json:config'] = 'Configure json plugin';
 $string['remotegroupfield'] = 'Remote group field';
 $string['localgroupfield'] = 'Local group field';
 $string['auth_remove_suspend_unenrol'] = 'Suspend internal and unenrol user from course';
+$string['extremovedaction'] = 'External unenrol action';
+$string['extremovedaction_help'] = 'Select action to carry out when user enrolment disappears from external enrolment source. <br>Please note<br>- Some user data and settings are purged from course during course unenrolment.<br>- The sync_enrolments task handles the unenrol action when the user details are still present in the Enrolment API but the corresponding enrolments have disappeared.<br>- The sync_enrolments_users task handles unenrolments for user if unenrolaction is set to \'Unenrol user from course\'.
+The unenrolments are executed when a user is completely missing from the Enrolment API but exists in the User API.';
+

--- a/settings.php
+++ b/settings.php
@@ -128,7 +128,7 @@ if ($hassiteconfig) {
             ENROL_EXT_REMOVED_KEEP           => get_string('extremovedkeep', 'enrol'),
             ENROL_EXT_REMOVED_SUSPEND        => get_string('extremovedsuspend', 'enrol'),
             ENROL_EXT_REMOVED_SUSPENDNOROLES => get_string('extremovedsuspendnoroles', 'enrol'));
-        $settings->add(new admin_setting_configselect('enrol_json/unenrolaction', get_string('extremovedaction', 'enrol'), get_string('extremovedaction_help', 'enrol'), ENROL_EXT_REMOVED_UNENROL, $options));
+        $settings->add(new admin_setting_configselect('enrol_json/unenrolaction', get_string('extremovedaction', 'enrol_json'), get_string('extremovedaction_help', 'enrol_json'), ENROL_EXT_REMOVED_UNENROL, $options));
 
     }
 }

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_json';
 $plugin->release = '0.1.3';
-$plugin->version = 2025091100;
+$plugin->version = 2025092600;
 $plugin->requires = 2020110900;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hi 
Currently the user has to be mentioned in the Enrolment API with  enrolments for unenrolments to take place      
For e.g. if a user has to unenrolled from all their courses then the below needs to be sent in the enrolment API. 
This will no longer be needed when the user is mentioned in the student API and completely disappears from the enrolment API, they will be unenrolled from all the courses they were enrolled in using JSON enrolment method. This will be achieved via the new schedule task  sync_enrolments_users

```
        {
		"adAccount": "azaria.green",
		"enrolments": [
			{
				"course": "CPT105-2526-S1",
				"courseId": "CPT105-2526-S1",
				"role": "student",
				"groups": []
			}
		]
	},
	{
		"adAccount": "a.kahu",
		"enrolments": []
	}
```


