### PR TITLE
Unenrol suspended users with rule sync

### DIFF
--- a/classes/task/sync_users.php
+++ b/classes/task/sync_users.php
@@ -22,6 +22,7 @@
  */
 
 namespace enrol_json\task;
+require_once($CFG->dirroot . '/enrol/json/lib.php');
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/classes/task/sync_users_all.php
+++ b/classes/task/sync_users_all.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Sync users task
+ * Sync enrolments task
  * @package   enrol_json
  * @copyright 2021 Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -26,12 +26,12 @@ namespace enrol_json\task;
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Class sync_enrolments
+ * Class sync_users_all
  * @package   enrol_json
  * @copyright 2021 Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class sync_users extends \core\task\scheduled_task {
+class sync_users_all extends \core\task\scheduled_task {
 
     /**
      * Name for this task.
@@ -39,7 +39,7 @@ class sync_users extends \core\task\scheduled_task {
      * @return string
      */
     public function get_name() {
-        return get_string('syncuserstask', 'enrol_json');
+        return get_string('syncuserssalltask', 'enrol_json');
     }
 
     /**
@@ -48,7 +48,6 @@ class sync_users extends \core\task\scheduled_task {
     public function execute() {
 
         $trace = new \text_progress_trace();
-
         if (!enrol_is_enabled('json')) {
             $trace->output('Plugin not enabled');
             return;
@@ -57,22 +56,16 @@ class sync_users extends \core\task\scheduled_task {
             $trace->output('User sync disabled');
             return;
         }
-        if (!empty($removeuser = get_config('enrol_json', 'removeuser'))) {
-            if ($removeuser == AUTH_REMOVEUSER_SUSPEND_UNENROL) {
-                $trace->output("Task cannot be executed. The plugin setting ".
-                    get_string('auth_remove_user_key', 'auth') .' is set to '.
-                    get_string('auth_remove_suspend_unenrol', 'enrol_json'). '. You need to run sync_users_all task instead')  ;
-            }
-            return;
-        }
+
         $enrol = enrol_get_plugin('json');
         if (!$enrol->is_configured()) {
             $trace->output('Plugin not configured');
             return;
         }
+
         \core_php_time_limit::raise();
         raise_memory_limit(MEMORY_HUGE);
 
-        $enrol->sync_users($trace, true);
+        $enrol->sync_users($trace);
     }
 }

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -53,5 +53,15 @@ $tasks = [
         'month' => '*',
         'dayofweek' => '*',
         'disabled' => true
+    ],
+    [
+        'classname' => '\enrol_json\task\sync_users_all',
+        'blocking' => 0,
+        'minute' => 'R',
+        'hour' => 'R',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*',
+        'disabled' => true
     ]
 ];

--- a/lang/en/enrol_json.php
+++ b/lang/en/enrol_json.php
@@ -50,10 +50,15 @@ $string['json:config'] = 'Configure json plugin';
 $string['remotegroupfield'] = 'Remote group field';
 $string['localgroupfield'] = 'Local group field';
 $string['auth_remove_suspend_unenrol'] = 'Suspend internal and unenrol user from course';
+$string['auth_remove_user'] = 'Specify what to do with internal user account during mass synchronisation when user was removed from external source.
+Only suspended users are automatically restored if they reappear in the external source.
+If \'Suspend internal and unenrol user from course\' option is selected then \'sync_users_all\' task needs to be executed while disabling \'sync_users\' task.
+';
 $string['extremovedaction'] = 'External unenrol action';
 $string['extremovedaction_help'] = 'Select action to carry out when user enrolment disappears from external enrolment source. <br>Please note<br>- Some user data and settings are purged from course during course unenrolment.<br>- The sync_enrolments task handles the unenrol action when the user details are still present in the Enrolment API but the corresponding enrolments have disappeared.<br>- The sync_enrolments_users task handles unenrolments for user if unenrolaction is set to \'Unenrol user from course\'.
 The unenrolments are executed when a user is completely missing from the Enrolment API but exists in the User API.';
 $string['rulesyncheader'] = 'Rule sync settings';
+$string['rulesyncheader_desc'] = 'Accounts following the below rules will be included in the sync';
 $string['ruleitems'] = 'Rule sync items';
 $string['ruleitems_desc'] = 'Add rule sync configuration in CSV format. Add one rule per each line in format fieldname, ruleidentifier, actionvalue. For e.g. field_map_email, endswith, @school.com';
-
+$string['syncuserssalltask'] = 'Sync users all';

--- a/lib.php
+++ b/lib.php
@@ -204,8 +204,7 @@ class enrol_json_plugin extends enrol_plugin {
                         $functioname = $item['ruleidentifier'];
                         $fieldname = $this->config->{$item['fieldname']};
                         if (!$functioname($row->{$fieldname}, $item['actionvalue'])) {
-                            mtrace("User skip as missing rule {$functioname} for account
-                             ".  $row->{$fieldname});
+                            mtrace("User skip as missing rule {$functioname} for account ".  $row->{$fieldname});
                             continue;
                         }
                     }

--- a/settings.php
+++ b/settings.php
@@ -79,7 +79,7 @@ if ($hassiteconfig) {
 
         $settings->add(new admin_setting_configselect('enrol_json/removeuser',
             new lang_string('auth_remove_user_key', 'auth'),
-            new lang_string('auth_remove_user', 'auth'), AUTH_REMOVEUSER_KEEP, $deleteopt));
+            new lang_string('auth_remove_user', 'enrol_json'), AUTH_REMOVEUSER_KEEP, $deleteopt));
 
 
         $authplugin = get_auth_plugin('manual');
@@ -130,7 +130,8 @@ if ($hassiteconfig) {
         $settings->add(new admin_setting_configselect('enrol_json/unenrolaction', get_string('extremovedaction', 'enrol_json'), get_string('extremovedaction_help', 'enrol_json'), ENROL_EXT_REMOVED_UNENROL, $options));
 
         // Label and Sync Options.
-        $settings->add(new admin_setting_heading('enrol_json/rulesyncheader', new lang_string('rulesyncheader', 'enrol_json'), ''));
+        $settings->add(new admin_setting_heading('enrol_json/rulesyncheader', new lang_string('rulesyncheader', 'enrol_json'),
+        new lang_string('rulesyncheader_desc', 'enrol_json')));
         $settings->add(new admin_setting_configtextarea('enrol_json/ruleitems', new lang_string('ruleitems', 'enrol_json'),
         new lang_string('ruleitems_desc', 'enrol_json'), '', PARAM_RAW, '50', '10'));
 

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_json';
 $plugin->release = '0.1.3';
-$plugin->version = 2025092600;
+$plugin->version = 2025110600;
 $plugin->requires = 2020110900;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hi 

The new 'Suspend internally and unenrol user from course' feature implemented relies on the User API endpoint to return a complete list of users. I will have updated the functionality of rules exclusion to account for this scenario.

Changes include
- A new task to include all user accounts which is necessary for the  'Suspend internally and unenrol user from course' setting
- Move rules application to be applied to the records in the database of the site

Regards,
Sumaiya